### PR TITLE
Make buildings informations white on grey in health advisor window

### DIFF
--- a/src/window/advisor/health.c
+++ b/src/window/advisor/health.c
@@ -46,38 +46,38 @@ static int draw_background(void)
     inner_panel_draw(32, 108, 36, 5);
 
     // bathhouses
-    lang_text_draw_amount(8, 24, building_count_total(BUILDING_BATHHOUSE), 40, 112, FONT_NORMAL_GREEN);
-    text_draw_number_centered(building_count_active(BUILDING_BATHHOUSE), 150, 112, 100, FONT_NORMAL_GREEN);
-    lang_text_draw_centered(56, 2, 290, 112, 120, FONT_NORMAL_GREEN);
-    lang_text_draw_centered(56, 2, 440, 112, 160, FONT_NORMAL_GREEN);
+    lang_text_draw_amount(8, 24, building_count_total(BUILDING_BATHHOUSE), 40, 112, FONT_NORMAL_WHITE);
+    text_draw_number_centered(building_count_active(BUILDING_BATHHOUSE), 150, 112, 100, FONT_NORMAL_WHITE);
+    lang_text_draw_centered(56, 2, 290, 112, 120, FONT_NORMAL_WHITE);
+    lang_text_draw_centered(56, 2, 440, 112, 160, FONT_NORMAL_WHITE);
 
     // barbers
-    lang_text_draw_amount(8, 26, building_count_total(BUILDING_BARBER), 40, 132, FONT_NORMAL_GREEN);
-    text_draw_number_centered(building_count_active(BUILDING_BARBER), 150, 132, 100, FONT_NORMAL_GREEN);
-    lang_text_draw_centered(56, 2, 290, 132, 120, FONT_NORMAL_GREEN);
-    lang_text_draw_centered(56, 2, 440, 132, 160, FONT_NORMAL_GREEN);
+    lang_text_draw_amount(8, 26, building_count_total(BUILDING_BARBER), 40, 132, FONT_NORMAL_WHITE);
+    text_draw_number_centered(building_count_active(BUILDING_BARBER), 150, 132, 100, FONT_NORMAL_WHITE);
+    lang_text_draw_centered(56, 2, 290, 132, 120, FONT_NORMAL_WHITE);
+    lang_text_draw_centered(56, 2, 440, 132, 160, FONT_NORMAL_WHITE);
 
     // clinics
-    lang_text_draw_amount(8, 28, building_count_total(BUILDING_DOCTOR), 40, 152, FONT_NORMAL_GREEN);
-    text_draw_number_centered(building_count_active(BUILDING_DOCTOR), 150, 152, 100, FONT_NORMAL_GREEN);
-    lang_text_draw_centered(56, 2, 290, 152, 120, FONT_NORMAL_GREEN);
-    lang_text_draw_centered(56, 2, 440, 152, 160, FONT_NORMAL_GREEN);
+    lang_text_draw_amount(8, 28, building_count_total(BUILDING_DOCTOR), 40, 152, FONT_NORMAL_WHITE);
+    text_draw_number_centered(building_count_active(BUILDING_DOCTOR), 150, 152, 100, FONT_NORMAL_WHITE);
+    lang_text_draw_centered(56, 2, 290, 152, 120, FONT_NORMAL_WHITE);
+    lang_text_draw_centered(56, 2, 440, 152, 160, FONT_NORMAL_WHITE);
 
     // hospitals
-    lang_text_draw_amount(8, 30, building_count_total(BUILDING_HOSPITAL), 40, 172, FONT_NORMAL_GREEN);
-    text_draw_number_centered(building_count_active(BUILDING_HOSPITAL), 150, 172, 100, FONT_NORMAL_GREEN);
+    lang_text_draw_amount(8, 30, building_count_total(BUILDING_HOSPITAL), 40, 172, FONT_NORMAL_WHITE);
+    text_draw_number_centered(building_count_active(BUILDING_HOSPITAL), 150, 172, 100, FONT_NORMAL_WHITE);
 
     int width = text_draw_number(1000 * building_count_active(BUILDING_HOSPITAL), '@', " ",
-        280, 172, FONT_NORMAL_GREEN);
-    lang_text_draw(56, 6, 280 + width, 172, FONT_NORMAL_GREEN);
+        280, 172, FONT_NORMAL_WHITE);
+    lang_text_draw(56, 6, 280 + width, 172, FONT_NORMAL_WHITE);
 
     int pct_hospital = city_culture_coverage_hospital();
     if (pct_hospital == 0) {
-        lang_text_draw_centered(57, 10, 440, 172, 160, FONT_NORMAL_GREEN);
+        lang_text_draw_centered(57, 10, 440, 172, 160, FONT_NORMAL_WHITE);
     } else if (pct_hospital < 100) {
-        lang_text_draw_centered(57, pct_hospital / 10 + 11, 440, 172, 160, FONT_NORMAL_GREEN);
+        lang_text_draw_centered(57, pct_hospital / 10 + 11, 440, 172, 160, FONT_NORMAL_WHITE);
     } else {
-        lang_text_draw_centered(57, 21, 440, 172, 160, FONT_NORMAL_GREEN);
+        lang_text_draw_centered(57, 21, 440, 172, 160, FONT_NORMAL_WHITE);
     }
 
     lang_text_draw_multiline(56, 7 + get_health_advice(), 60, 194, 512, FONT_NORMAL_BLACK);


### PR DESCRIPTION
Before:
<img width="647" height="298" alt="image" src="https://github.com/user-attachments/assets/a2070d53-50cf-4537-8b7d-9f91b57422b0" />

After:
<img width="649" height="296" alt="image" src="https://github.com/user-attachments/assets/c2fea5f7-fb9d-4ad7-9451-23defd939ecd" />

For reference:
<img width="651" height="266" alt="image" src="https://github.com/user-attachments/assets/32ee5baf-7d9a-4844-8d98-33abd0d5c8c0" />
<img width="651" height="378" alt="image" src="https://github.com/user-attachments/assets/3a87bf1e-c6aa-4114-8744-eb234f1f4868" />
<img width="648" height="280" alt="image" src="https://github.com/user-attachments/assets/46c1f55c-8114-4a4a-bc4a-bb71d1088375" />
