### PR TITLE
Refactoring: simplify build menu

### DIFF
--- a/src/building/menu.c
+++ b/src/building/menu.c
@@ -51,198 +51,167 @@ void building_menu_enable_all(void)
     }
 }
 
-static void enable_house(int *enabled, building_type menu_building_type)
+static int building_enabled_normal(building_type type)
 {
-    if (menu_building_type >= BUILDING_HOUSE_VACANT_LOT && menu_building_type <= BUILDING_HOUSE_LUXURY_PALACE) {
-        *enabled = 1;
+    switch (type) {
+        case BUILDING_NONE:
+            return 0;
+
+        case BUILDING_WHEAT_FARM:
+            return scenario_building_allowed(type) && empire_can_produce_resource(RESOURCE_WHEAT);
+        case BUILDING_VEGETABLE_FARM:
+            return scenario_building_allowed(type) && empire_can_produce_resource(RESOURCE_VEGETABLES);
+        case BUILDING_FRUIT_FARM:
+            return scenario_building_allowed(type) && empire_can_produce_resource(RESOURCE_FRUIT);
+        case BUILDING_PIG_FARM:
+            return scenario_building_allowed(type) && empire_can_produce_resource(RESOURCE_MEAT);
+        case BUILDING_OLIVE_FARM:
+            return scenario_building_allowed(type) && empire_can_produce_resource(RESOURCE_OLIVES);
+        case BUILDING_VINES_FARM:
+            return scenario_building_allowed(type) && empire_can_produce_resource(RESOURCE_VINES);
+
+        case BUILDING_CLAY_PIT:
+            return scenario_building_allowed(type) && empire_can_produce_resource(RESOURCE_CLAY);
+        case BUILDING_TIMBER_YARD:
+            return scenario_building_allowed(type) && empire_can_produce_resource(RESOURCE_TIMBER);
+        case BUILDING_IRON_MINE:
+            return scenario_building_allowed(type) && empire_can_produce_resource(RESOURCE_IRON);
+        case BUILDING_MARBLE_QUARRY:
+            return scenario_building_allowed(type) && empire_can_produce_resource(RESOURCE_MARBLE);
+
+        case BUILDING_POTTERY_WORKSHOP:
+            return scenario_building_allowed(type) && empire_can_produce_resource_potentially(RESOURCE_POTTERY);
+        case BUILDING_FURNITURE_WORKSHOP:
+            return scenario_building_allowed(type) && empire_can_produce_resource_potentially(RESOURCE_FURNITURE);
+        case BUILDING_OIL_WORKSHOP:
+            return scenario_building_allowed(type) && empire_can_produce_resource_potentially(RESOURCE_OIL);
+        case BUILDING_WINE_WORKSHOP:
+            return scenario_building_allowed(type) && empire_can_produce_resource_potentially(RESOURCE_WINE);
+        case BUILDING_WEAPONS_WORKSHOP:
+            return scenario_building_allowed(type) && empire_can_produce_resource_potentially(RESOURCE_WEAPONS);
+
+        case BUILDING_TRIUMPHAL_ARCH:
+            return city_buildings_triumphal_arch_available();
+
+        default:
+            return scenario_building_allowed(type);
     }
 }
 
-static void enable_clear(int *enabled, building_type menu_building_type)
+static int building_enabled_tutorial1_start(building_type type)
 {
-    if (menu_building_type == BUILDING_CLEAR_LAND) {
-        *enabled = 1;
+    switch (type) {
+        case BUILDING_HOUSE_VACANT_LOT:
+        case BUILDING_CLEAR_LAND:
+        case BUILDING_WELL:
+        case BUILDING_ROAD:
+            return building_enabled_normal(type);
+        default:
+            return 0;
     }
 }
 
-static void enable_cycling_temples_if_allowed(building_type type)
+static int building_enabled_tutorial1_after_fire(building_type type)
 {
-    int sub = (type == BUILDING_MENU_SMALL_TEMPLES) ? BUILD_MENU_SMALL_TEMPLES : BUILD_MENU_LARGE_TEMPLES;
-    menu_enabled[sub][0] = config_get(CONFIG_UI_ALLOW_CYCLING_TEMPLES);
-}
-
-static void enable_if_allowed(int *enabled, building_type menu_building_type, building_type type)
-{
-    if (menu_building_type == type && scenario_building_allowed(type)) {
-        *enabled = 1;
-        if (type == BUILDING_MENU_SMALL_TEMPLES || type == BUILDING_MENU_LARGE_TEMPLES) {
-            enable_cycling_temples_if_allowed(type);
-        }
+    switch (type) {
+        case BUILDING_PREFECTURE:
+        case BUILDING_MARKET:
+            return building_enabled_normal(type);
+        default:
+            return building_enabled_tutorial1_start(type);
     }
 }
 
-static void disable_raw(int *enabled, building_type menu_building_type, building_type type, int resource)
+static int building_enabled_tutorial1_after_collapse(building_type type)
 {
-    if (type == menu_building_type && !empire_can_produce_resource(resource)) {
-        *enabled = 0;
+    switch (type) {
+        case BUILDING_ENGINEERS_POST:
+        case BUILDING_SENATE:
+            return building_enabled_normal(type);
+        default:
+            return building_enabled_tutorial1_after_fire(type);
     }
 }
 
-static void disable_finished(int *enabled, building_type menu_building_type, building_type type, int resource)
+static int building_enabled_tutorial2_start(building_type type)
 {
-    if (type == menu_building_type && !empire_can_produce_resource_potentially(resource)) {
-        *enabled = 0;
+    switch (type) {
+        case BUILDING_HOUSE_VACANT_LOT:
+        case BUILDING_CLEAR_LAND:
+        case BUILDING_WELL:
+        case BUILDING_ROAD:
+        case BUILDING_PREFECTURE:
+        case BUILDING_ENGINEERS_POST:
+        case BUILDING_SENATE:
+        case BUILDING_MARKET:
+        case BUILDING_GRANARY:
+        case BUILDING_MENU_FARMS:
+        case BUILDING_WHEAT_FARM:
+        case BUILDING_VEGETABLE_FARM:
+        case BUILDING_FRUIT_FARM:
+        case BUILDING_PIG_FARM:
+        case BUILDING_OLIVE_FARM:
+        case BUILDING_VINES_FARM:
+        case BUILDING_MENU_SMALL_TEMPLES:
+        case BUILDING_SMALL_TEMPLE_CERES:
+        case BUILDING_SMALL_TEMPLE_NEPTUNE:
+        case BUILDING_SMALL_TEMPLE_MERCURY:
+        case BUILDING_SMALL_TEMPLE_MARS:
+        case BUILDING_SMALL_TEMPLE_VENUS:
+            return building_enabled_normal(type);
+        default:
+            return 0;
     }
 }
 
-static void enable_normal(int *enabled, building_type type)
+static int building_enabled_tutorial2_up_to_250(building_type type)
 {
-    enable_house(enabled, type);
-    enable_clear(enabled, type);
-    enable_if_allowed(enabled, type, BUILDING_ROAD);
-    enable_if_allowed(enabled, type, BUILDING_DRAGGABLE_RESERVOIR);
-    enable_if_allowed(enabled, type, BUILDING_AQUEDUCT);
-    enable_if_allowed(enabled, type, BUILDING_FOUNTAIN);
-    enable_if_allowed(enabled, type, BUILDING_WELL);
-    enable_if_allowed(enabled, type, BUILDING_BARBER);
-    enable_if_allowed(enabled, type, BUILDING_BATHHOUSE);
-    enable_if_allowed(enabled, type, BUILDING_DOCTOR);
-    enable_if_allowed(enabled, type, BUILDING_HOSPITAL);
-    enable_if_allowed(enabled, type, BUILDING_MENU_SMALL_TEMPLES);
-    enable_if_allowed(enabled, type, BUILDING_MENU_LARGE_TEMPLES);
-    enable_if_allowed(enabled, type, BUILDING_ORACLE);
-    enable_if_allowed(enabled, type, BUILDING_SCHOOL);
-    enable_if_allowed(enabled, type, BUILDING_ACADEMY);
-    enable_if_allowed(enabled, type, BUILDING_LIBRARY);
-    enable_if_allowed(enabled, type, BUILDING_THEATER);
-    enable_if_allowed(enabled, type, BUILDING_AMPHITHEATER);
-    enable_if_allowed(enabled, type, BUILDING_COLOSSEUM);
-    enable_if_allowed(enabled, type, BUILDING_HIPPODROME);
-    enable_if_allowed(enabled, type, BUILDING_GLADIATOR_SCHOOL);
-    enable_if_allowed(enabled, type, BUILDING_LION_HOUSE);
-    enable_if_allowed(enabled, type, BUILDING_ACTOR_COLONY);
-    enable_if_allowed(enabled, type, BUILDING_CHARIOT_MAKER);
-    enable_if_allowed(enabled, type, BUILDING_FORUM);
-    enable_if_allowed(enabled, type, BUILDING_SENATE);
-    enable_if_allowed(enabled, type, BUILDING_GOVERNORS_HOUSE);
-    enable_if_allowed(enabled, type, BUILDING_GOVERNORS_VILLA);
-    enable_if_allowed(enabled, type, BUILDING_GOVERNORS_PALACE);
-    enable_if_allowed(enabled, type, BUILDING_SMALL_STATUE);
-    enable_if_allowed(enabled, type, BUILDING_MEDIUM_STATUE);
-    enable_if_allowed(enabled, type, BUILDING_LARGE_STATUE);
-    enable_if_allowed(enabled, type, BUILDING_GARDENS);
-    enable_if_allowed(enabled, type, BUILDING_PLAZA);
-    enable_if_allowed(enabled, type, BUILDING_ENGINEERS_POST);
-    enable_if_allowed(enabled, type, BUILDING_MISSION_POST);
-    enable_if_allowed(enabled, type, BUILDING_SHIPYARD);
-    enable_if_allowed(enabled, type, BUILDING_WHARF);
-    enable_if_allowed(enabled, type, BUILDING_DOCK);
-    enable_if_allowed(enabled, type, BUILDING_WALL);
-    enable_if_allowed(enabled, type, BUILDING_TOWER);
-    enable_if_allowed(enabled, type, BUILDING_GATEHOUSE);
-    enable_if_allowed(enabled, type, BUILDING_PREFECTURE);
-    enable_if_allowed(enabled, type, BUILDING_FORT);
-    enable_if_allowed(enabled, type, BUILDING_MILITARY_ACADEMY);
-    enable_if_allowed(enabled, type, BUILDING_BARRACKS);
-    enable_if_allowed(enabled, type, BUILDING_DISTRIBUTION_CENTER_UNUSED);
-    enable_if_allowed(enabled, type, BUILDING_MENU_FARMS);
-    enable_if_allowed(enabled, type, BUILDING_MENU_RAW_MATERIALS);
-    enable_if_allowed(enabled, type, BUILDING_MENU_WORKSHOPS);
-    enable_if_allowed(enabled, type, BUILDING_MARKET);
-    enable_if_allowed(enabled, type, BUILDING_GRANARY);
-    enable_if_allowed(enabled, type, BUILDING_WAREHOUSE);
-    enable_if_allowed(enabled, type, BUILDING_LOW_BRIDGE);
-    enable_if_allowed(enabled, type, BUILDING_SHIP_BRIDGE);
-    if (type == BUILDING_TRIUMPHAL_ARCH) {
-        if (city_buildings_triumphal_arch_available()) {
-            *enabled = 1;
-        }
+    switch (type) {
+        case BUILDING_DRAGGABLE_RESERVOIR:
+        case BUILDING_AQUEDUCT:
+        case BUILDING_FOUNTAIN:
+            return building_enabled_normal(type);
+        default:
+            return building_enabled_tutorial2_start(type);
     }
 }
 
-static void enable_tutorial1_start(int *enabled, building_type type)
+static int building_enabled_tutorial2_up_to_450(building_type type)
 {
-    enable_house(enabled, type);
-    enable_clear(enabled, type);
-    enable_if_allowed(enabled, type, BUILDING_WELL);
-    enable_if_allowed(enabled, type, BUILDING_ROAD);
+    switch (type) {
+        case BUILDING_GARDENS:
+        case BUILDING_ACTOR_COLONY:
+        case BUILDING_THEATER:
+        case BUILDING_BATHHOUSE:
+        case BUILDING_SCHOOL:
+            return building_enabled_normal(type);
+        default:
+            return building_enabled_tutorial2_up_to_250(type);
+    }
 }
 
-static void enable_tutorial1_after_fire(int *enabled, building_type type)
+static int building_enabled_tutorial2_after_450(building_type type)
 {
-    enable_tutorial1_start(enabled, type);
-    enable_if_allowed(enabled, type, BUILDING_PREFECTURE);
-    enable_if_allowed(enabled, type, BUILDING_MARKET);
-}
-
-static void enable_tutorial1_after_collapse(int *enabled, building_type type)
-{
-    enable_tutorial1_after_fire(enabled, type);
-    enable_if_allowed(enabled, type, BUILDING_ENGINEERS_POST);
-    enable_if_allowed(enabled, type, BUILDING_SENATE);
-}
-
-static void enable_tutorial2_start(int *enabled, building_type type)
-{
-    enable_house(enabled, type);
-    enable_clear(enabled, type);
-    enable_if_allowed(enabled, type, BUILDING_WELL);
-    enable_if_allowed(enabled, type, BUILDING_ROAD);
-    enable_if_allowed(enabled, type, BUILDING_PREFECTURE);
-    enable_if_allowed(enabled, type, BUILDING_ENGINEERS_POST);
-    enable_if_allowed(enabled, type, BUILDING_SENATE);
-    enable_if_allowed(enabled, type, BUILDING_MARKET);
-    enable_if_allowed(enabled, type, BUILDING_GRANARY);
-    enable_if_allowed(enabled, type, BUILDING_MENU_FARMS);
-    enable_if_allowed(enabled, type, BUILDING_MENU_SMALL_TEMPLES);
-}
-
-static void enable_tutorial2_up_to_250(int *enabled, building_type type)
-{
-    enable_tutorial2_start(enabled, type);
-    enable_if_allowed(enabled, type, BUILDING_DRAGGABLE_RESERVOIR);
-    enable_if_allowed(enabled, type, BUILDING_AQUEDUCT);
-    enable_if_allowed(enabled, type, BUILDING_FOUNTAIN);
-}
-
-static void enable_tutorial2_up_to_450(int *enabled, building_type type)
-{
-    enable_tutorial2_up_to_250(enabled, type);
-    enable_if_allowed(enabled, type, BUILDING_GARDENS);
-    enable_if_allowed(enabled, type, BUILDING_ACTOR_COLONY);
-    enable_if_allowed(enabled, type, BUILDING_THEATER);
-    enable_if_allowed(enabled, type, BUILDING_BATHHOUSE);
-    enable_if_allowed(enabled, type, BUILDING_SCHOOL);
-}
-
-static void enable_tutorial2_after_450(int *enabled, building_type type)
-{
-    enable_tutorial2_up_to_450(enabled, type);
-    enable_if_allowed(enabled, type, BUILDING_MENU_RAW_MATERIALS);
-    enable_if_allowed(enabled, type, BUILDING_MENU_WORKSHOPS);
-    enable_if_allowed(enabled, type, BUILDING_WAREHOUSE);
-    enable_if_allowed(enabled, type, BUILDING_FORUM);
-    enable_if_allowed(enabled, type, BUILDING_AMPHITHEATER);
-    enable_if_allowed(enabled, type, BUILDING_GLADIATOR_SCHOOL);
-}
-
-static void disable_resources(int *enabled, building_type type)
-{
-    disable_raw(enabled, type, BUILDING_WHEAT_FARM, RESOURCE_WHEAT);
-    disable_raw(enabled, type, BUILDING_VEGETABLE_FARM, RESOURCE_VEGETABLES);
-    disable_raw(enabled, type, BUILDING_FRUIT_FARM, RESOURCE_FRUIT);
-    disable_raw(enabled, type, BUILDING_PIG_FARM, RESOURCE_MEAT);
-    disable_raw(enabled, type, BUILDING_OLIVE_FARM, RESOURCE_OLIVES);
-    disable_raw(enabled, type, BUILDING_VINES_FARM, RESOURCE_VINES);
-    disable_raw(enabled, type, BUILDING_CLAY_PIT, RESOURCE_CLAY);
-    disable_raw(enabled, type, BUILDING_TIMBER_YARD, RESOURCE_TIMBER);
-    disable_raw(enabled, type, BUILDING_IRON_MINE, RESOURCE_IRON);
-    disable_raw(enabled, type, BUILDING_MARBLE_QUARRY, RESOURCE_MARBLE);
-    disable_finished(enabled, type, BUILDING_POTTERY_WORKSHOP, RESOURCE_POTTERY);
-    disable_finished(enabled, type, BUILDING_FURNITURE_WORKSHOP, RESOURCE_FURNITURE);
-    disable_finished(enabled, type, BUILDING_OIL_WORKSHOP, RESOURCE_OIL);
-    disable_finished(enabled, type, BUILDING_WINE_WORKSHOP, RESOURCE_WINE);
-    disable_finished(enabled, type, BUILDING_WEAPONS_WORKSHOP, RESOURCE_WEAPONS);
+    switch (type) {
+        case BUILDING_MENU_RAW_MATERIALS:
+        case BUILDING_CLAY_PIT:
+        case BUILDING_TIMBER_YARD:
+        case BUILDING_IRON_MINE:
+        case BUILDING_MARBLE_QUARRY:
+        case BUILDING_MENU_WORKSHOPS:
+        case BUILDING_POTTERY_WORKSHOP:
+        case BUILDING_FURNITURE_WORKSHOP:
+        case BUILDING_OIL_WORKSHOP:
+        case BUILDING_WINE_WORKSHOP:
+        case BUILDING_WEAPONS_WORKSHOP:
+        case BUILDING_WAREHOUSE:
+        case BUILDING_FORUM:
+        case BUILDING_AMPHITHEATER:
+        case BUILDING_GLADIATOR_SCHOOL:
+            return building_enabled_normal(type);
+        default:
+            return building_enabled_tutorial2_up_to_450(type);
+    }
 }
 
 void building_menu_update(void)
@@ -252,42 +221,39 @@ void building_menu_update(void)
         for (int item = 0; item < BUILD_MENU_ITEM_MAX; item++) {
             int building_type = MENU_BUILDING_TYPE[sub][item];
             int *menu_item = &menu_enabled[sub][item];
-            // first 12 items always disabled
-            if (sub < 12) {
-                *menu_item = 0;
-            } else {
-                *menu_item = 1;
-            }
             switch (tutorial_buttons) {
                 case TUT1_BUILD_START:
-                    enable_tutorial1_start(menu_item, building_type);
+                    *menu_item = building_enabled_tutorial1_start(building_type);
                     break;
                 case TUT1_BUILD_AFTER_FIRE:
-                    enable_tutorial1_after_fire(menu_item, building_type);
+                    *menu_item = building_enabled_tutorial1_after_fire(building_type);
                     break;
                 case TUT1_BUILD_AFTER_COLLAPSE:
-                    enable_tutorial1_after_collapse(menu_item, building_type);
+                    *menu_item = building_enabled_tutorial1_after_collapse(building_type);
                     break;
                 case TUT2_BUILD_START:
-                    enable_tutorial2_start(menu_item, building_type);
+                    *menu_item = building_enabled_tutorial2_start(building_type);
                     break;
                 case TUT2_BUILD_UP_TO_250:
-                    enable_tutorial2_up_to_250(menu_item, building_type);
+                    *menu_item = building_enabled_tutorial2_up_to_250(building_type);
                     break;
                 case TUT2_BUILD_UP_TO_450:
-                    enable_tutorial2_up_to_450(menu_item, building_type);
+                    *menu_item = building_enabled_tutorial2_up_to_450(building_type);
                     break;
                 case TUT2_BUILD_AFTER_450:
-                    enable_tutorial2_after_450(menu_item, building_type);
+                    *menu_item = building_enabled_tutorial2_after_450(building_type);
                     break;
                 default:
-                    enable_normal(menu_item, building_type);
+                    *menu_item = building_enabled_normal(building_type);
                     break;
             }
-
-            disable_resources(menu_item, building_type);
         }
     }
+    if (!config_get(CONFIG_UI_ALLOW_CYCLING_TEMPLES)) {
+        menu_enabled[BUILD_MENU_SMALL_TEMPLES][0] = 0;
+        menu_enabled[BUILD_MENU_LARGE_TEMPLES][0] = 0;
+    }
+
     changed = 1;
 }
 

--- a/src/window/city.c
+++ b/src/window/city.c
@@ -192,7 +192,7 @@ static void toggle_pause(void)
 
 static void set_construction_building_type(building_type type)
 {
-    if (scenario_building_allowed(type) && building_menu_is_enabled(type)) {
+    if (building_menu_is_enabled(type)) {
         building_construction_cancel();
         building_construction_set_type(type);
         window_request_refresh();


### PR DESCRIPTION
Should make the code a bit easier to read and remove the distinction between main menus and sub-menus.