### PR TITLE
Standardize display of ratings goals

### DIFF
--- a/src/graphics/tooltip.c
+++ b/src/graphics/tooltip.c
@@ -264,7 +264,7 @@ static void draw_senate_tooltip(tooltip_context *c)
     lang_text_draw_colored(68, 149, x + 5, y + 19, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
     text_draw_number_colored(city_rating_culture(), '@', " ",
         x + 140, y + 19, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
-    if (!scenario_is_open_play() && scenario_criteria_culture_enabled()) {
+    if (!scenario_is_open_play() && scenario_criteria_culture_enabled() && scenario_criteria_culture() > 0) {
         text_draw_number_colored(scenario_criteria_culture(), '(', ")",
             x + 140 + width, y + 19, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
     }
@@ -272,7 +272,7 @@ static void draw_senate_tooltip(tooltip_context *c)
     lang_text_draw_colored(68, 150, x + 5, y + 33, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
     text_draw_number_colored(city_rating_prosperity(), '@', " ",
         x + 140, y + 33, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
-    if (!scenario_is_open_play() && scenario_criteria_prosperity_enabled()) {
+    if (!scenario_is_open_play() && scenario_criteria_prosperity_enabled() && scenario_criteria_prosperity() > 0) {
         text_draw_number_colored(scenario_criteria_prosperity(), '(', ")",
             x + 140 + width, y + 33, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
     }
@@ -280,7 +280,7 @@ static void draw_senate_tooltip(tooltip_context *c)
     lang_text_draw_colored(68, 151, x + 5, y + 47, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
     text_draw_number_colored(city_rating_peace(), '@', " ",
         x + 140, y + 47, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
-    if (!scenario_is_open_play() && scenario_criteria_peace_enabled()) {
+    if (!scenario_is_open_play() && scenario_criteria_peace_enabled() && scenario_criteria_peace() > 0) {
         text_draw_number_colored(scenario_criteria_peace(), '(', ")",
             x + 140 + width, y + 47, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
     }
@@ -288,7 +288,7 @@ static void draw_senate_tooltip(tooltip_context *c)
     lang_text_draw_colored(68, 152, x + 5, y + 61, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
     text_draw_number_colored(city_rating_favor(), '@', " ",
         x + 140, y + 61, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
-    if (!scenario_is_open_play() && scenario_criteria_favor_enabled()) {
+    if (!scenario_is_open_play() && scenario_criteria_favor_enabled() && scenario_criteria_favor() > 0) {
         text_draw_number_colored(scenario_criteria_favor(), '(', ")",
             x + 140 + width, y + 61, FONT_SMALL_PLAIN, COLOR_TOOLTIP);
     }

--- a/src/widget/sidebar/extra.c
+++ b/src/widget/sidebar/extra.c
@@ -182,9 +182,13 @@ static int draw_extra_info_objective(
     } else {
         lang_text_draw(text_group, text_id, x_offset + 11, y_offset, FONT_NORMAL_WHITE);
     }
-    font_t font = obj->value >= obj->target ? FONT_NORMAL_GREEN : FONT_NORMAL_RED;
-    int width = text_draw_number(obj->value, '@', "", x_offset + 11, y_offset + EXTRA_INFO_LINE_SPACE, font);
-    text_draw_number(obj->target, '(', ")", x_offset + 11 + width, y_offset + EXTRA_INFO_LINE_SPACE, font);
+    if (obj->target > 0) {
+        font_t font = obj->value >= obj->target ? FONT_NORMAL_GREEN : FONT_NORMAL_RED;
+        int width = text_draw_number(obj->value, '@', "", x_offset + 11, y_offset + EXTRA_INFO_LINE_SPACE, font);
+        text_draw_number(obj->target, '(', ")", x_offset + 11 + width, y_offset + EXTRA_INFO_LINE_SPACE, font);
+    } else {
+        text_draw_number(obj->value, '@', "", x_offset + 11, y_offset + EXTRA_INFO_LINE_SPACE, FONT_NORMAL_GREEN);
+    }
     return EXTRA_INFO_LINE_SPACE * 2;
 }
 

--- a/src/window/advisor/ratings.c
+++ b/src/window/advisor/ratings.c
@@ -41,11 +41,13 @@ static int draw_background(void)
     outer_panel_draw(0, 0, 40, ADVISOR_HEIGHT);
     image_draw(image_group(GROUP_ADVISOR_ICONS) + 3, 10, 10);
     int width = lang_text_draw(53, 0, 60, 12, FONT_LARGE_BLACK);
-    if (!scenario_criteria_population_enabled() || scenario_is_open_play()) {
-        lang_text_draw(53, 7, 80 + width, 17, FONT_NORMAL_BLACK);
-    } else {
-        width += lang_text_draw(53, 6, 80 + width, 17, FONT_NORMAL_BLACK);
-        text_draw_number(scenario_criteria_population(), '@', ")", 80 + width, 17, FONT_NORMAL_BLACK);
+    if (!scenario_is_open_play()) {
+        if (!scenario_criteria_population_enabled() || scenario_criteria_population() <= 0) {
+            lang_text_draw(53, 7, 80 + width, 17, FONT_NORMAL_BLACK);
+        } else {
+            width += lang_text_draw(53, 6, 80 + width, 17, FONT_NORMAL_BLACK);
+            text_draw_number(scenario_criteria_population(), '@', ")", 80 + width, 17, FONT_NORMAL_BLACK);
+        }
     }
 
     image_draw(image_group(GROUP_RATINGS_BACKGROUND), 60, 48);
@@ -58,9 +60,11 @@ static int draw_background(void)
     button_border_draw(80, 286, 110, 66, focus_button_id == SELECTED_RATING_CULTURE);
     lang_text_draw_centered(53, 1, 80, 294, 110, FONT_NORMAL_BLACK);
     text_draw_number_centered(culture, 80, 309, 100, FONT_LARGE_BLACK);
-    width = text_draw_number(has_culture_goal ? scenario_criteria_culture() : 0,
+    if (!open_play) {
+        width = text_draw_number(has_culture_goal ? scenario_criteria_culture() : 0,
             '@', " ", 85, 334, FONT_NORMAL_BLACK);
-    lang_text_draw(53, 5, 85 + width, 334, FONT_NORMAL_BLACK);
+        lang_text_draw(53, 5, 85 + width, 334, FONT_NORMAL_BLACK);
+    }
     int has_reached = !has_culture_goal || culture >= scenario_criteria_culture();
     draw_rating_column(110, 274, culture, has_reached);
 
@@ -70,9 +74,11 @@ static int draw_background(void)
     button_border_draw(200, 286, 110, 66, focus_button_id == SELECTED_RATING_PROSPERITY);
     lang_text_draw_centered(53, 2, 200, 294, 110, FONT_NORMAL_BLACK);
     text_draw_number_centered(prosperity, 200, 309, 100, FONT_LARGE_BLACK);
-    width = text_draw_number(has_prosperity_goal ? scenario_criteria_prosperity() : 0,
+    if (!open_play) {
+        width = text_draw_number(has_prosperity_goal ? scenario_criteria_prosperity() : 0,
             '@', " ", 205, 334, FONT_NORMAL_BLACK);
-    lang_text_draw(53, 5, 205 + width, 334, FONT_NORMAL_BLACK);
+        lang_text_draw(53, 5, 205 + width, 334, FONT_NORMAL_BLACK);
+    }
     has_reached = !has_prosperity_goal || prosperity >= scenario_criteria_prosperity();
     draw_rating_column(230, 274, prosperity, has_reached);
 
@@ -82,9 +88,11 @@ static int draw_background(void)
     button_border_draw(320, 286, 110, 66, focus_button_id == SELECTED_RATING_PEACE);
     lang_text_draw_centered(53, 3, 320, 294, 110, FONT_NORMAL_BLACK);
     text_draw_number_centered(peace, 320, 309, 100, FONT_LARGE_BLACK);
-    width = text_draw_number(has_peace_goal ? scenario_criteria_peace() : 0,
+    if (!open_play) {
+        width = text_draw_number(has_peace_goal ? scenario_criteria_peace() : 0,
             '@', " ", 325, 334, FONT_NORMAL_BLACK);
-    lang_text_draw(53, 5, 325 + width, 334, FONT_NORMAL_BLACK);
+        lang_text_draw(53, 5, 325 + width, 334, FONT_NORMAL_BLACK);
+    }
     has_reached = !has_peace_goal || peace >= scenario_criteria_peace();
     draw_rating_column(350, 274, peace, has_reached);
 
@@ -94,9 +102,11 @@ static int draw_background(void)
     button_border_draw(440, 286, 110, 66, focus_button_id == SELECTED_RATING_FAVOR);
     lang_text_draw_centered(53, 4, 440, 294, 110, FONT_NORMAL_BLACK);
     text_draw_number_centered(favor, 440, 309, 100, FONT_LARGE_BLACK);
-    width = text_draw_number(has_favor_goal ? scenario_criteria_favor() : 0,
+    if (!open_play) {
+        width = text_draw_number(has_favor_goal ? scenario_criteria_favor() : 0,
             '@', " ", 445, 334, FONT_NORMAL_BLACK);
-    lang_text_draw(53, 5, 445 + width, 334, FONT_NORMAL_BLACK);
+        lang_text_draw(53, 5, 445 + width, 334, FONT_NORMAL_BLACK);
+    }
     has_reached = !has_favor_goal || favor >= scenario_criteria_favor();
     draw_rating_column(470, 274, favor, has_reached);
 


### PR DESCRIPTION
On Brundisium:

Before:
<img width="530" height="283" alt="image" src="https://github.com/user-attachments/assets/41a2b5f4-65fd-4394-a5e3-c40779252e50" />

After:
<img width="477" height="317" alt="image" src="https://github.com/user-attachments/assets/f9b1ec7c-1741-4e10-ad75-ebb1caf81f2c" />

For open play:
<img width="650" height="500" alt="image" src="https://github.com/user-attachments/assets/d1408a0a-9273-40dc-af12-01d06c5f8f53" />

